### PR TITLE
fix: update backToMultiPost URL in EditorHeader

### DIFF
--- a/src/components/CodemirrorEditor/EditorHeader/index.vue
+++ b/src/components/CodemirrorEditor/EditorHeader/index.vue
@@ -101,7 +101,7 @@ function copy() {
 }
 
 function backToMultiPost() {
-  window.location.href = `https://multipost.app/publish`
+  window.location.href = `https://multipost.app/dashboard/publish`
 }
 </script>
 


### PR DESCRIPTION
- Changed the redirect URL in backToMultiPost function to point to the dashboard instead of the publish page.